### PR TITLE
add grunt-cli dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "web-push": "^3.1.0"
   },
   "dependencies": {
-    "body-parser": "^1.15.2"
+    "body-parser": "^1.15.2",
+    "grunt-cli": "^1.2.0"
   }
 }


### PR DESCRIPTION
after `npm start`, the following error will occur if grunt-cli is not installed.
>gotham_imperial_hotel@1.0.0 start /Users/apple/Desktop//github/gotham_imperial_hotel
 grunt serve

>sh: grunt: command not found

>npm ERR! Darwin 16.6.0
>npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "start"
>npm ERR! node v7.0.0
>npm ERR! npm  v4.2.0
>npm ERR! file sh
>npm ERR! code ELIFECYCLE
>npm ERR! errno ENOENT
>npm ERR! syscall spawn
>npm ERR! gotham_imperial_hotel@1.0.0 start: grunt serve
>npm ERR! spawn ENOENT
>npm ERR!
>npm ERR! Failed at the gotham_imperial_hotel@1.0.0 start script 'grunt serve'.
>npm ERR! Make sure you have the latest version of node.js and npm installed.
>npm ERR! If you do, this is most likely a problem with the gotham_imperial_hotel package,
>npm ERR! not with npm itself.
>npm ERR! Tell the author that this fails on your system:
>npm ERR!     grunt serve
>npm ERR! You can get information on how to open an issue for this project with:
>npm ERR!     npm bugs gotham_imperial_hotel
>npm ERR! Or if that isn't available, you can get their info via:
>npm ERR!     npm owner ls gotham_imperial_hotel
>npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/apple/.npm/_logs/2017-07-08T19_04_49_927Z-debug.log`

